### PR TITLE
Fix iframe going straight to link token page when calling 'open' second time

### DIFF
--- a/src/connect-initialize.js
+++ b/src/connect-initialize.js
@@ -8,7 +8,6 @@ var Fuse = {
     const url = options.overrideBaseUrl || "https://connect.letsfuse.com";
 
     var iframe = document.createElement("iframe");
-    iframe.setAttribute("src", `${url}/intro?client_secret=${clientSecret}`);
     iframe.style.position = "fixed";
     iframe.style.top = "0";
     iframe.style.left = "0";
@@ -75,6 +74,7 @@ var Fuse = {
 
     return {
       open: function () {
+        iframe.setAttribute("src", `${url}/intro?client_secret=${clientSecret}`);
         document.body.appendChild(iframe);
         document.body.style.overflow = "hidden";
       },


### PR DESCRIPTION
[WebStorm - react-fuse-connect – useFuseConnect.tsx - 17 August 2023 - Watch Video](https://www.loom.com/share/024e79fafaed42f7b73f5349bed152dd)